### PR TITLE
Freezed prawn gem version to support ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ else
 gem "nokogiri"
 end
 gem "open-uri-cached"
-gem "prawn"
+gem "prawn", "< 2.0.0"
 gem 'json'
 gem "system_timer" if RUBY_VERSION =~ /^1\.8\./ && RUBY_PLATFORM =~ /darwin|linux/
 


### PR DESCRIPTION
Later versions of prawn require ruby 2.0
