### PR TITLE
Fix mailer picking wrong release version

### DIFF
--- a/lib/backlogs_hooks.rb
+++ b/lib/backlogs_hooks.rb
@@ -16,10 +16,10 @@ module BacklogsPlugin
       def helper_issues_show_detail_after_setting(context={ })
       	begin
           if context[:detail].prop_key == 'release_id'
-            r = RbRelease.find_by_id(context[:detail].value)
+            r = RbRelease.find_by_id(context[:detail].value) if is_int?(context[:detail].value)
             context[:detail].value = r.name unless r.nil? || r.name.nil?
 
-            r = RbRelease.find_by_id(context[:detail].old_value)
+            r = RbRelease.find_by_id(context[:detail].old_value) if is_int?(context[:detail].old_value)
             context[:detail].old_value = r.name unless r.nil? || r.name.nil?
           end
         rescue => e
@@ -430,6 +430,10 @@ module BacklogsPlugin
         end
       end
 
+      private
+      def is_int?(value)
+        value.to_s == value.to_i.to_s
+      end
     end
   end
 end


### PR DESCRIPTION
When creating the html version of the mail when a release is set, the
`helper_issues_show_detail_after_setting hook` is called twice. The
first call updates the hook context so that the value is set for the
chosen release, for example "1.12.0". The second time, the hook attempts
to find a release with id "1.12.0" which rails automatically turns into
"1" (since id is an integer). This causes the finder to find the release
that has id=1, in our case. "1.3.1", sending the incorrect version in
the mail.
